### PR TITLE
Fix location of postgres persistent data in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ systems({
     shell: "/bin/bash",
     wait: {"retry": 25, "timeout": 1000},
     mounts: {
-      '/var/lib/postgresql': persistent("postgresql-#{system.name}"),
+      '/var/lib/postgresql/data': persistent("postgresql-#{system.name}"),
       '/var/log/postgresql': path("./log/postgresql"),
     },
     ports: {


### PR DESCRIPTION
In both 9.3 and 9.4 base images it's `/var/lib/postgresql/data` that is the volume that needs to be mounted. Mounting `/var/lib/postgresql` causes data loss when container stops.

https://github.com/docker-library/postgres/blob/master/9.3/Dockerfile#L43
https://github.com/docker-library/postgres/blob/master/9.4/Dockerfile#L43
